### PR TITLE
make: fix arm64 detection in ARCH auto-detect

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -41,7 +41,7 @@ ARCH := $(shell uname -m | sed 's/x86_64/x86/' \
                          | sed 's/aarch64/arm64/' \
                          | sed 's/ppc64le/powerpc/' \
                          | sed 's/mips.*/mips/' \
-                         | sed 's/arm.*/arm/' \
+                         | sed 's/^arm(v[0-9].*)?/arm/' \
                          | sed 's/riscv64/riscv/')
 
 # vmlinux.h 路径


### PR DESCRIPTION
## 问题
Rockchip 等 aarch64 主机会被 `uname -m` 报为 `aarch64`，原先的
`sed 's/arm.*/arm/'` 会把已经替换成 `arm64` 的字符串再次压成 `arm`，
导致使用 32 位 vmlinux.h 和 `__TARGET_ARCH_arm`，kprobe/tp 等示例在
arm64 上加载失败。

## 修改
* 在 [src/Makefile.common](cci:7://file:///home/radxa/ebpf-tutorial/src/Makefile.common:0:0-0:0) 的架构检测中，将 `sed 's/arm.*/arm/'`
  改为 `sed 's/^arm(v[0-9].*)?/arm/'`，只归一化 armv7/armhf 这类 32 位名称，
  保留 `arm64`。

